### PR TITLE
适配 iPhone 8 / SE 2 / SE 3 屏幕分辨率

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -135,7 +135,7 @@ const Home: NextPage = () => {
               width={30}
               height={30}
               alt="1 icon"
-              className="mb-5 sm:mb-0"
+              className="mb-5 xs:mb-0"
             />
             <p className="text-left font-medium">
               {t('step1')}{" "}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,11 @@ module.exports = {
     "./app/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      screens: {
+        'xs': '375px'
+      }
+    },
   },
   plugins: [require("@tailwindcss/forms"), require("@headlessui/tailwindcss")],
 };


### PR DESCRIPTION
在 iPhone 8 / SE 2 / SE 3 屏幕上，下图所示看着别扭，所以加了个 `375px` 断点。

<img width="334" alt="iShot_2023-02-14_14 28 51" src="https://user-images.githubusercontent.com/18460218/218657022-4731e321-df2a-4c6b-821a-955756f87012.png">
